### PR TITLE
separate benchmarks for oscillator vs vibrato test

### DIFF
--- a/benchmarks_manyOscillators.js
+++ b/benchmarks_manyOscillators.js
@@ -1,0 +1,98 @@
+var numberOfOscillators = 50
+
+function makeMockAudioProcessEvent(blockSize) {
+    var buffer = new Float32Array(blockSize),
+        e = {
+            outputBuffer: {
+                length: 1024
+            },
+            inputBuffer: {}
+        },
+        getChannelData = function () {
+            return buffer;
+        };
+
+    e.outputBuffer.getChannelData = getChannelData;
+    e.inputBuffer.getChannelData = getChannelData;
+
+    return e;
+}
+
+function scriptProcessorNodeTester(audioProcessHandlerFn, blockSize, numSamples) {
+    var that = {
+        audioProcessHandlerFn: audioProcessHandlerFn,
+        numSamples: numSamples || 44100,
+        blockSize: blockSize,
+        startTime: undefined,
+        endTime: undefined
+    };
+
+    that.mockEvent = makeMockAudioProcessEvent(that.blockSize);
+
+    that.test = function () {
+        var e = that.mockEvent,
+            processor = that.audioProcessHandlerFn,
+            numCalls = Math.ceil(that.numSamples / that.blockSize),
+            i;
+
+        for (i = 0; i < numCalls; i++) {
+            processor(e);
+        }
+    };
+
+    return that;
+};
+
+function flockingTest() {
+    flock.init({
+        bufferSize: 1024
+    });
+    
+    for( var i = 0; i < numberOfOscillators; i++ ) {
+      var synth = flock.synth({
+          synthDef: {
+              ugen: "flock.ugen.sinOsc",
+              freq: 440 + i * 20,
+              mul: 1 / length
+          }
+      }).play()
+    }
+
+    flock.enviro.shared.audioStrategy.jsNode.disconnect(0);
+    var writeSamplesFn = flock.enviro.shared.audioStrategy.writeSamples;
+    var timer = scriptProcessorNodeTester(writeSamplesFn, 1024, 4410);
+
+    return timer.test;
+};
+
+function gibberishTest() {
+    Gibberish.init(1024);
+        
+    for( var i = 0; i < numberOfOscillators; i++ ) {
+      new Gibberish.Sine(440 + i * 20, 1 / length ).connect()
+    }
+    
+    Gibberish.node.disconnect(0);
+    var timer = scriptProcessorNodeTester(Gibberish.audioProcess, 1024, 4410);
+
+    return timer.test;
+};
+
+function runBenchmarks() {
+    sheep.test([
+        {
+            name: "Gibberish",
+            test: gibberishTest(),
+            onSuccess: function () {
+                Gibberish.clear();
+            }
+        },
+        {
+            name: "Flocking",
+            test: flockingTest(),
+            onSuccess: function () {
+                flock.enviro.shared.stop();
+            }
+        }
+    ], true);
+}

--- a/benchmarks_vibrato.js
+++ b/benchmarks_vibrato.js
@@ -1,0 +1,108 @@
+  function makeMockAudioProcessEvent(blockSize) {
+    var buffer = new Float32Array(blockSize),
+        e = {
+            outputBuffer: {
+                length: 1024
+            },
+            inputBuffer: {}
+        },
+        getChannelData = function () {
+            return buffer;
+        };
+
+    e.outputBuffer.getChannelData = getChannelData;
+    e.inputBuffer.getChannelData = getChannelData;
+
+    return e;
+}
+
+function scriptProcessorNodeTester(audioProcessHandlerFn, blockSize, numSamples) {
+    var that = {
+        audioProcessHandlerFn: audioProcessHandlerFn,
+        numSamples: numSamples || 44100,
+        blockSize: blockSize,
+        startTime: undefined,
+        endTime: undefined
+    };
+
+    that.mockEvent = makeMockAudioProcessEvent(that.blockSize);
+
+    that.test = function () {
+        var e = that.mockEvent,
+            processor = that.audioProcessHandlerFn,
+            numCalls = Math.ceil(that.numSamples / that.blockSize),
+            i;
+
+        for (i = 0; i < numCalls; i++) {
+            processor(e);
+        }
+    };
+
+    return that;
+};
+
+function flockingTest() {
+    flock.init({
+        bufferSize: 1024
+    });
+
+    var synth = flock.synth({
+        synthDef: {
+            ugen: "flock.ugen.sinOsc",
+            freq: {
+                ugen: "flock.ugen.sinOsc",
+                freq: 4,
+                mul: {
+                    ugen: "flock.ugen.sinOsc",
+                    freq: 0.1,
+                    mul: 50
+                },
+                add: 440
+            },
+            mul: 0.25
+        }
+    });
+
+    synth.play();
+    flock.enviro.shared.audioStrategy.jsNode.disconnect(0);
+    var writeSamplesFn = flock.enviro.shared.audioStrategy.writeSamples;
+    var timer = scriptProcessorNodeTester(writeSamplesFn, 1024, 44100);
+
+    return timer.test;
+};
+
+function gibberishTest() {
+    Gibberish.init(1024);
+    Gibberish.Time.export();
+    Gibberish.Binops.export();
+
+    var mod1 = new Gibberish.Sine(4, 0),
+        mod2 = new Gibberish.Sine(0.1, 50);
+
+    mod1.amp = mod2;
+    var sin = new Gibberish.Sine( Add(mod1, 440), 0.25 ).connect();
+
+    Gibberish.node.disconnect(0);
+    var timer = scriptProcessorNodeTester(Gibberish.audioProcess, 1024, 44100);
+
+    return timer.test;
+};
+
+function runBenchmarks() {
+    sheep.test([
+        {
+            name: "Gibberish",
+            test: gibberishTest(),
+            onSuccess: function () {
+                Gibberish.clear();
+            }
+        },
+        {
+            name: "Flocking",
+            test: flockingTest(),
+            onSuccess: function () {
+                flock.enviro.shared.stop();
+            }
+        }
+    ], true);
+}

--- a/compare-flocking-gibberish.html
+++ b/compare-flocking-gibberish.html
@@ -10,7 +10,7 @@
         <script src="third-party/gibberish/gibberish.min.js"></script>
         <script src="third-party/sheep/third-party/js/spin.min.js"></script>
         <script src="third-party/sheep/js/sheep.js"></script>
-        <script src="benchmarks.js"></script>
+        <script src="benchmarks_manyOscillators.js"></script>
     </head>
 
     <body>


### PR DESCRIPTION
No worries if you don't want to pull this... it's adding an additional test for 50 audio-rate sine oscillators. I guess at some point we should figure out an interface for running different tests and keep track of different results.
